### PR TITLE
Add petSD support

### DIFF
--- a/README
+++ b/README
@@ -10,6 +10,7 @@ Both communicate via a serial line.
 
 Currently this hardware is supported:
 	- XS-1541 	Communication via serial line over USB
+	- petSD   	Communication via serial line over USB
 
 For more information see the README files in the subdirectories
 
@@ -28,7 +29,7 @@ also available on later versions of the GPL, the AtMega firmware is
 ONLY(!) available under GPL V2.
 
 (C) 2012 Andre Fachat <afachat@gmx.de>,
-	 Ingo Korb, Thomas Winkler, and others!
+	 Ingo Korb, Thomas Winkler, Nils Eilers and others!
 
 Please see the individual files for specific copyright notices.
 
@@ -88,8 +89,11 @@ in favour of a device number switch, an SD card interface, and maybe a serial co
 REFERENCES
 ----------
 
-XS-1541: The currently supported hardware by T. Winkler is described here:
+XS-1541: The hardware by T. Winkler is described here:
 	http://xs1541.t-winkler.net/
+
+petSD: The hardware by N. Eilers is described here:
+	http://home.germany.net/nils.eilers/petsd/
 
 sd2iec:	Some files in this firmware are derived from the sd2iec project by I. Korb
 	http://www.c64-wiki.com/index.php/sd2iec_%28firmware%29

--- a/firmware/README
+++ b/firmware/README
@@ -2,6 +2,7 @@ This file describes how to build and use the XD-2031 firmware.
 
 Currently supported hardware:
 	- XS-1541
+	- petSD
 
 Note that there are some subdirectories for "avr", or "xs1541", which apply
 to the architecture (like "avr") or the device (like "xs1541"). A device 

--- a/firmware/avr/arch-timer.h
+++ b/firmware/avr/arch-timer.h
@@ -29,13 +29,9 @@
 #define ARCH_TIMER_H
 
 #include "config.h"         // for F_CPU needed by util/delay.h
+#include "compat.h"
 #include <util/delay.h>
 #include <avr/io.h>
-
-/* no idea how this got generated in sd2iec */
-/* from asmconfig.h */
-#define TCNT0 _SFR_IO8(0X26)
-#define TOV0 0
 
 #define SYSTEM_TICK_HANDLER ISR(TIMER1_COMPA_vect)
 

--- a/firmware/avr/compat.h
+++ b/firmware/avr/compat.h
@@ -23,7 +23,7 @@
 #ifndef COMPAT_H
 #define COMPAT_H
 
-#if defined __AVR_ATmega644__ || defined __AVR_ATmega644P__
+#if defined __AVR_ATmega644__ || defined __AVR_ATmega644P__ || defined __AVR_ATmega1284P__
 #  define RXC   RXC0
 #  define RXEN  RXEN0
 #  define TXC   TXC0

--- a/firmware/petSD/Makefile
+++ b/firmware/petSD/Makefile
@@ -1,0 +1,19 @@
+
+# directory name used in includes
+DEVICE=petSD
+
+DEVICEFILES=petSD/ieeehw.c
+DEVICEDEPS=petSD/device.h petSD/config.h petSD/atn.o petSD/ieeehw.h
+
+DEVICEASMOBJ=atn.o
+
+ARCHDEVICE=-mmcu=atmega1284p
+#ARCHDEVICE=-mmcu=atmega644p
+
+## Assembler files
+petSD/atn.o: petSD/atn.S
+	$(CC) $(INCLUDES) $(ARCHDEVICE) $(ASMFLAGS) -c  $<
+
+deviceclean:
+	rm -f atn.o
+

--- a/firmware/petSD/README
+++ b/firmware/petSD/README
@@ -1,0 +1,17 @@
+*****   B A D   F U S E S   S E T T I N G S   *****
+
+petSDs shipped until July 2012 had AVR fuse settings that may cause
+data loss over the serial line. 
+If you purchased your petSD before this time, you probably won't be 
+able to run the new XD-2031 firmware before changing the fuses first.
+Unfortunately, this cannot be made with the SD-card boot loader update. 
+
+Changing the fuses requires an in-system-programmer like a STK-200 or
+AVRISPmkII. Use AVRDUDE and run:
+
+avrdude -p m1284p -v -y -U lfuse:w:0xf7:m -U hfuse:w:0xd2:m -U efuse:w:0xff:m
+
+WARNING:   IF YOU DON'T KNOW WHAT YOU'RE DOING, YOU MAY BRICK YOUR DEVICE!
+========   Please feel free to email nils.eilers@gmx.de for further advice.
+
+

--- a/firmware/petSD/atn.S
+++ b/firmware/petSD/atn.S
@@ -1,0 +1,76 @@
+/**************************************************************************
+
+    atn.S  -- ATN acknowledge (software, interrupt driven)
+
+    This file is part of XD-2031 -- Serial line filesystem server for CBMs
+
+    Copyright (C) 2012 Andre Fachat <afachat@gmx.de>
+    Copyrifht (C) 2012 Nils Eilers  <nils.eilers@gmx.de>
+
+    XD-2031 is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA  02110-1301, USA.
+
+**************************************************************************/
+
+
+#include <avr/io.h>
+#include <avr/interrupt.h>
+
+/**
+ * ATN interrupt handler
+ */
+
+;---------------------------------------------------------------------------
+; ATN change interrupt
+
+.global INT0_vect                                             ; Cycles in IRQ
+INT0_vect:
+        ; Save registers
+        push    r2                    ; Make place for status register  2
+        in      r2, _SFR_IO_ADDR(SREG); Save status register            1
+        push    r16                   ; Save working register           2
+
+        ; ATN acknowledge
+        lds     r16, PORTC            ; PC6: NDAC, PC7: NRFD            2
+        andi    r16, 255 - _BV(PC6) | _BV(PC7);                         1
+        sts     PORTC, r16            ; NDAC low, NRFD low              2
+        
+        lds     r16, DDRC             ; NDAC + NRFD as outputs          2
+        ori     r16, _BV(PC6) | _BV(PC7);                               1
+        sts     DDRC, r16             ;                                 2
+
+        ; Prerequistes for possible change of flow direction if 
+        ; ATN came when device was talker
+        lds     r16, DDRB             ; DAV as input                    2
+        andi    r16, 255 - _BV(PB2)   ;                                 1
+        sts     DDRB, r16             ;                                 2
+        lds     r16, DDRD             ; EOI as input                    2
+        andi    r16, 255 - _BV(PD7)   ;                                 1
+        sts     DDRD, r16             ;                                 2
+
+        lds     r16, PORTB            ; Make sure, bus drivers are in   2
+        andi    r16, 255 -  _BV(PB0)  ; TE=0 listen mode                1
+        sts     PORTB, r16            ;                                 2
+                                      ;                               ===
+                                      ;                                30 
+
+        ; End of interrupt routine, restore registers
+        pop     r16
+        out     _SFR_IO_ADDR(SREG), r2
+        pop     r2
+        reti
+
+.end
+        

--- a/firmware/petSD/config.h
+++ b/firmware/petSD/config.h
@@ -1,0 +1,44 @@
+/**************************************************************************
+
+    config.h -- common configurations
+
+    This file is part of XD-2031 -- Serial line filesystem server for CBMs
+
+    Copyright (C) 2012 Andre Fachat <afachat@gmx.de>
+    Copyrifht (C) 2012 Nils Eilers  <nils.eilers@gmx.de>
+
+    XD-2031 is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+    MA  02110-1301, USA.
+
+**************************************************************************/
+
+
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define F_CPU       18432000UL
+
+// LED configuration
+#define LED_DDR     DDRD
+#define LED_PORT    PORTD
+#define LED_BIT     PD5       // green LED (may be part of bi-color LED)
+// not used         PD6       // red LED   (may be part of bi-color LED)
+
+// buffer sizes
+#define CONFIG_COMMAND_BUFFER_SIZE      120
+#define CONFIG_ERROR_BUFFER_SIZE        46
+
+#endif
+

--- a/firmware/petSD/device.h
+++ b/firmware/petSD/device.h
@@ -1,0 +1,75 @@
+/**************************************************************************
+
+    device.h -- device dependant definitions
+
+    This file is part of XD-2031 -- Serial line filesystem server for CBMs
+
+    Copyright (C) 2012 Andre Fachat <afachat@gmx.de>
+    Copyrifht (C) 2012 Nils Eilers  <nils.eilers@gmx.de>
+
+    XD-2031 is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA  02110-1301, USA.
+
+**************************************************************************/
+
+
+#ifndef PETSD_H
+#define PETSD_H
+
+// we have the 75160/75161 pairs
+#define HAVE_7516X
+
+// bus definitions
+#  define IEEE_PORT_TE          PORTB   /* TE */
+#  define IEEE_DDR_TE           DDRB
+#  define IEEE_PIN_TE           PB0
+#  define IEEE_PORT_DC          PORTC   /* DC */
+#  define IEEE_DDR_DC           DDRC
+#  define IEEE_PIN_DC           PC5
+
+#  define IEEE_INPUT_ATN        PIND    /* ATN */
+#  define IEEE_PORT_ATN         PORTD
+#  define IEEE_DDR_ATN          DDRD
+#  define IEEE_PIN_ATN          PD2
+#  define IEEE_INPUT_NDAC       PINC    /* NDAC */
+#  define IEEE_PORT_NDAC        PORTC
+#  define IEEE_DDR_NDAC         DDRC
+#  define IEEE_PIN_NDAC         PC6
+#  define IEEE_INPUT_NRFD       PINC    /* NRFD */
+#  define IEEE_PORT_NRFD        PORTC
+#  define IEEE_DDR_NRFD         DDRC
+#  define IEEE_PIN_NRFD         PC7
+#  define IEEE_INPUT_DAV        PINB    /* DAV */
+#  define IEEE_PORT_DAV         PORTB
+#  define IEEE_DDR_DAV          DDRB
+#  define IEEE_PIN_DAV          PB2
+#  define IEEE_INPUT_EOI        PIND    /* EOI */
+#  define IEEE_PORT_EOI         PORTD
+#  define IEEE_DDR_EOI          DDRD
+#  define IEEE_PIN_EOI          PD7
+
+#  define IEEE_D_PIN            PINA    /* Data */
+#  define IEEE_D_PORT           PORTA
+#  define IEEE_D_DDR            DDRA
+
+#define IEEE_ATN_HANDLER        ISR(IEEE_ATN_INT_VECT)
+#define IEEE_ATN_INT            INT0
+
+#define HW_NAME			"petSD"
+
+#define	IEEE_SECADDR_OFFSET	0
+#define	IEC_SECADDR_OFFSET	16
+
+#endif

--- a/firmware/petSD/ieeehw.c
+++ b/firmware/petSD/ieeehw.c
@@ -1,0 +1,94 @@
+/**************************************************************************
+
+    ieeehw.c  -- IEEE-488 bus routines
+
+    This file is part of XD-2031 -- Serial line filesystem server for CBMs
+
+    Copyright (C) 2012 Andre Fachat <afachat@gmx.de>
+    Copyrifht (C) 2012 Nils Eilers  <nils.eilers@gmx.de>
+
+    XD-2031 is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License    
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+    MA  02110-1301, USA.
+
+**************************************************************************/
+
+
+#include "ieeehw.h"
+
+/* ------------------------------------------------------------------------- 
+ * local variables
+ */
+
+// when set, disable ATN acknowledgement
+uint8_t is_atna = 0;
+uint8_t is_ndacout = 0;
+uint8_t is_nrfdout = 0;
+
+/* ------------------------------------------------------------------------- */
+/*  Interrupt handling                                                       */
+/* ------------------------------------------------------------------------- */
+
+static void ieee_interrupts_init(void)  {
+  DDRD &= ~_BV(PD2);        // define ATN as input
+  PORTD |= _BV(PD2);        // enable pull-up
+  EICRA |= _BV(ISC00);      // configure interrupt on falling edge of ATN
+  EIMSK |= _BV(INT0);       // enable interrupt
+  //debug_putps("Done init ieee ints"); debug_putcrlf();
+}
+
+/* IEEE-488 ATN interrupt using INT0 */
+static void set_atn_irq(uint8_t x) {
+#if DEBUG
+  debug_putps("ATN_IRQ:"); debug_puthex(x); debug_putcrlf();
+#endif
+  if (x)
+    EIMSK |= _BV(IEEE_ATN_INT);
+  else
+    EIMSK &= (uint8_t) ~_BV(IEEE_ATN_INT);
+}
+
+/* ------------------------------------------------------------------------- 
+ *  General functions
+ */
+
+void ieeehw_setup() {
+	// clear IEEE lines
+	atnahi();
+	clrd();
+	davhi();
+	nrfdhi();
+	ndachi();
+	eoihi();
+}
+
+void ieeehw_init() {
+
+    IEEE_DDR_TE |= _BV(IEEE_PIN_TE);                // Define TE as output
+    IEEE_PORT_TE &= (uint8_t) ~ _BV(IEEE_PIN_TE);   // TE=0
+    IEEE_DDR_DC |= _BV(IEEE_PIN_DC);                // Define DC as output
+    IEEE_PORT_DC |= _BV(IEEE_PIN_DC);               // DC=1 (device)
+
+	// disable ATN interrupt
+	set_atn_irq(0);
+
+	// clear IEEE lines
+	ieeehw_setup();
+
+	// start ATN interrupt handling
+	ieee_interrupts_init();
+}
+
+
+

--- a/firmware/petSD/ieeehw.h
+++ b/firmware/petSD/ieeehw.h
@@ -1,0 +1,239 @@
+/**************************************************************************
+
+    ieeehw.h  -- IEEE-488 bus routines
+
+    This file is part of XD-2031 -- Serial line filesystem server for CBMs
+
+    Copyright (C) 2012 Andre Fachat <afachat@gmx.de>
+    Copyrifht (C) 2012 Nils Eilers  <nils.eilers@gmx.de>
+
+    XD-2031 is free software: you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+    MA  02110-1301, USA.
+
+**************************************************************************/
+
+
+#ifndef IEEEHW_H
+#define IEEEHW_H
+
+#include <stdint.h>
+#include <avr/io.h>
+#include <avr/interrupt.h>
+
+#include "device.h"
+
+// IEEE hw code error codes
+
+#define E_OK        0
+#define E_ATN       1
+#define E_EOI       2
+#define E_TIME      4
+#define E_BRK       5
+#define E_NODEV     6
+
+extern uint8_t is_atna;         // output of ATNA
+extern uint8_t is_nrfdout;      // last output of NRFD before ATNA handling
+extern uint8_t is_ndacout;      // last output of NDAC before ATNA handling
+
+// ATN handling (input only)
+
+static inline uint8_t atnislo (void) {
+  return !(IEEE_INPUT_ATN & _BV(IEEE_PIN_ATN));
+}
+
+static inline uint8_t atnishi (void) {
+  return (IEEE_INPUT_ATN & _BV(IEEE_PIN_ATN));
+}
+
+// NDAC & NRFD handling
+// Note the order of method definition in this file depends on dependencies
+
+static inline void ndaclo (void) {
+ IEEE_PORT_NDAC &= (uint8_t)~_BV(IEEE_PIN_NDAC);    // NDAC low
+ is_ndacout = 0;
+}
+                                                    
+static inline void nrfdlo (void) {
+  IEEE_PORT_NRFD &= (uint8_t)~_BV(IEEE_PIN_NRFD);   // NRFD low
+  is_nrfdout = 0;
+}
+
+static inline void ndachi (void) {
+  // disable interrupt to avoid race condition
+  // of ATN irq between the atnishi() check and
+  // setting NDAC lo
+  cli();  
+  if (atnishi() || is_atna) {
+    IEEE_PORT_NDAC |= _BV(IEEE_PIN_NDAC);           // NDAC high
+  }
+  // allow interrupt again
+  sei();
+  is_ndacout = 1;
+}
+
+static inline void nrfdhi (void) {
+  // disable interrupt to avoid race condition
+  // of ATN irq between the atnishi() check and
+  // setting NDAC lo
+  cli();  
+  if (atnishi() || is_atna) {                       
+    IEEE_PORT_NRFD |= _BV(IEEE_PIN_NRFD);           // NRFD high
+  }
+  // allow interrupt again
+  sei();
+  is_nrfdout = 1;
+}
+
+static inline uint8_t ndacislo (void) {
+  return !(IEEE_INPUT_NDAC & _BV(IEEE_PIN_NDAC));
+}
+
+static inline uint8_t ndacishi (void) {
+  return (IEEE_INPUT_NDAC & _BV(IEEE_PIN_NDAC));
+}
+
+
+static inline uint8_t nrfdislo (void) {
+  return !(IEEE_INPUT_NRFD & _BV(IEEE_PIN_NRFD));
+}
+
+static inline uint8_t nrfdishi (void) {
+  return (IEEE_INPUT_NRFD & _BV(IEEE_PIN_NRFD));
+}
+
+// DAV handling
+
+static inline void davlo (void) {
+  IEEE_PORT_DAV &= (uint8_t)~_BV(IEEE_PIN_DAV);     // DAV low
+}
+
+static inline void davhi (void) {
+  IEEE_PORT_DAV |= _BV(IEEE_PIN_DAV);               // DAV high
+}
+
+static inline uint8_t davislo (void) {
+  return !(IEEE_INPUT_DAV & _BV(IEEE_PIN_DAV));
+}
+
+static inline uint8_t davishi (void) {
+  return (IEEE_INPUT_DAV & _BV(IEEE_PIN_DAV));
+}
+
+// EOI handling
+// Don't drive EOI active high because 75161 changes the
+// direction on ATN
+
+static inline void eoilo (void) {
+  IEEE_PORT_EOI &= (uint8_t)~_BV(IEEE_PIN_EOI);     // EOI low
+  IEEE_DDR_EOI |= (uint8_t) _BV(IEEE_PIN_EOI);      // EOI as output
+}
+
+static inline void eoihi (void) {
+  IEEE_DDR_EOI &= (uint8_t)~_BV(IEEE_PIN_EOI);      // EOI as input
+  IEEE_PORT_EOI |= (uint8_t)_BV(IEEE_PIN_EOI);      // Enable pull-up
+}
+
+static inline uint8_t eoiislo (void) {
+  return !(IEEE_INPUT_EOI & _BV(IEEE_PIN_EOI));
+}
+
+static inline uint8_t eoiishi (void) {
+  return (IEEE_INPUT_EOI & _BV(IEEE_PIN_EOI));
+}
+
+// TE handling
+
+static inline void telo (void) {
+  IEEE_PORT_TE &= (uint8_t) ~ _BV(IEEE_PIN_TE);     // TE low (listen)
+}
+
+static inline void tehi (void) {
+  IEEE_PORT_TE |= _BV(IEEE_PIN_TE);                 // TE high (talk)
+}
+
+// ATNA handling
+// (ATN acknowledge logic)
+
+// acknowledge ATN
+static inline void atnahi (void) {
+  is_atna = 0;
+}
+
+// disarm ATN acknowledge handling
+static inline void atnalo (void) {
+  if (!is_nrfdout) {
+    nrfdlo();
+  }
+  if (!is_ndacout) {
+    ndaclo();
+  }
+  is_atna = 1;
+}
+
+// data handling
+
+static inline void clrd (void) {
+  IEEE_D_PORT = 0xff;
+}
+
+static inline void wrd(uint8_t data) {
+  IEEE_D_PORT = (uint8_t) ~ data;
+}
+
+static inline uint8_t rdd (void) {
+  return (uint8_t) ~ IEEE_D_PIN;
+}
+
+// general functions
+
+void ieeehw_init (void);
+
+// resets the IEEE hardware after a transfer
+void ieeehw_setup (void);
+
+// switch hardware from receive to transmit (to talk)
+static inline void settx (void) {
+  IEEE_DDR_NDAC &= (uint8_t)~_BV(IEEE_PIN_NDAC);    // NDAC as input
+  IEEE_DDR_NRFD &= (uint8_t)~_BV(IEEE_PIN_NRFD);    // NRFD as input
+  IEEE_PORT_NDAC |= _BV(IEEE_PIN_NDAC);             // Enable NDAC pull-up
+  IEEE_PORT_NRFD |= _BV(IEEE_PIN_NRFD);             // Enable NRFD pull-up
+  davhi();                                          // Release DAV
+  eoihi();                                          // EOI high
+  IEEE_D_PORT = 0xff;                               // Release data lines
+  tehi();                                           // Bus driver => TALK
+  IEEE_DDR_DAV |= _BV(IEEE_PIN_DAV);                // DAV as output (high)
+  IEEE_D_DDR = 0xff;                                // Data as output (high)
+}
+
+// switch hardware from transmit to receive (after talk)
+// this happens after ATN, so nrfd and ndac are already low
+static inline void setrx (void) {
+  IEEE_DDR_DAV &= (uint8_t)~_BV(IEEE_PIN_DAV);      // DAV as input
+  IEEE_D_DDR = 0;                                   // Data as input
+  IEEE_PORT_DAV |= _BV(IEEE_PIN_DAV);               // Enable DAV pull-up 
+  IEEE_D_PORT = 0xff;                               // Enable data pull-ups
+  eoihi();                                          // Release EOI
+  nrfdhi();                                         // Release NRFD
+  ndachi();                                         // Release NDAC
+  telo();                                           // Bus driver => LISTEN
+  IEEE_DDR_NDAC |= _BV(IEEE_PIN_NDAC);              // NDAC as output
+  IEEE_DDR_NRFD |= (uint8_t) _BV(IEEE_PIN_NRFD);    // NRFD as output
+}
+
+// switch hardware to idle (same as settx here, but maybe different
+// with different hardware
+#define setidle() setrx()
+
+#endif


### PR DESCRIPTION
Initial support for the petSD hardware. An in-system-programmer is
required to reprogram the AVR fuses first. See petSD/README for details.
