### PR TITLE
Added commands FS_COPY, FS_DUPLICATE and FS_INITIALIZE

### DIFF
--- a/common/wireformat.h
+++ b/common/wireformat.h
@@ -65,8 +65,8 @@
 #define   FS_WRITE       8      /* push data */
 #define   FS_REPLY       9      /* return value */
 #define   FS_EOF         10     /* as FS_WRITE, but signal EOF with */
-#define	  FS_SEEK	 11	/* seek within a file */
-#define   FS_CLOSE	 12	/* close a channel */
+#define	 FS_SEEK        11	/* seek within a file */
+#define   FS_CLOSE       12	/* close a channel */
 
 #define   FS_MOVE      	 13	/* rename a file */
 #define   FS_DELETE      14	/* delete a file */
@@ -89,6 +89,9 @@
 
 #define   FS_CHARSET 	 27	/* send to the server the name of the requested character set for
 				   file names and directory entries */
+#define   FS_COPY        28   /* copy a file or merge files */
+#define   FS_DUPLICATE   29   /* duplicate a disk image or copy a directory */
+#define   FS_INITIALIZE  30   /* initialize (e.g. free buffers and remove file locks) */
 
 /*
  * BLOCK and DIRECT commands

--- a/firmware/cmd.c
+++ b/firmware/cmd.c
@@ -70,11 +70,18 @@ int8_t command_execute(uint8_t channel_no, bus_t *bus, errormsg_t *errormsg,
         // post-parse
 
 	switch (nameinfo.cmd) {
+		case CMD_INITIALIZE: // If a drive number is given, set the last used drive
+			if (command->command_buffer[1])
+            rtconf->last_used_drive = command->command_buffer[1] - 0x30;
 		case CMD_RENAME:
 		case CMD_SCRATCH:
 		case CMD_CD:
 		case CMD_MKDIR:
 		case CMD_RMDIR:
+      case CMD_VALIDATE:
+      case CMD_COPY:
+      case CMD_DUPLICATE:
+      case CMD_NEW:
 			// pass-through commands
 			// those are just being passed to the provider
 			// nameinfo cmd enum definition such that wireformat matches it
@@ -89,10 +96,6 @@ int8_t command_execute(uint8_t channel_no, bus_t *bus, errormsg_t *errormsg,
 			if (provider_assign( nameinfo.drive, (char*) nameinfo.name, (char*) nameinfo.name2 ) < 0) {
 				return file_submit_call(channel_no, FS_ASSIGN, command->command_buffer, errormsg, rtconf, callback, 1);
 			}
-			break;
-		case CMD_INITIALIZE:
-			// If a drive number is given, set the last used drive
-			if (command->command_buffer[1]) rtconf->last_used_drive = command->command_buffer[1] - 0x30;
 			break;
 		case CMD_UX:
 			rv = cmd_user(bus, (char*) command->command_buffer, errormsg);

--- a/firmware/cmd.h
+++ b/firmware/cmd.h
@@ -41,24 +41,24 @@ typedef enum {
         //
         CMD_NONE,
         CMD_SYNTAX,
-	CMD_OVERWRITE = FS_OPEN_OW,
+        CMD_OVERWRITE = FS_OPEN_OW,
         CMD_DIR = FS_OPEN_DR,
         //
         // CBM DOS commands
         //
-        CMD_INITIALIZE,
-        CMD_RENAME = FS_MOVE,
-        CMD_SCRATCH = FS_DELETE,
-	CMD_POSITION,
-	//
+        CMD_INITIALIZE = FS_INITIALIZE,
+        CMD_RENAME     = FS_MOVE,
+        CMD_SCRATCH    = FS_DELETE,
+        CMD_POSITION   = FS_POSITION,
+        CMD_VALIDATE   = FS_CHKDSK,
+        CMD_COPY       = FS_COPY,
+        CMD_DUPLICATE  = FS_DUPLICATE,
+        CMD_NEW        = FS_FORMAT,
+        CMD_BLOCK      = FS_BLOCK,
+        CMD_UX         = FS_SYNC, // makes no sense but doesn't conflict
+        //
         // unsupported
         //
-        // CMD_VALIDATE,
-        // CMD_COPY,
-        // CMD_DUPLICATE,
-        // CMD_NEW,
-        CMD_BLOCK = FS_BLOCK,
-        CMD_UX = FS_SYNC, // makes no sense but doesn't conflict
         // CMD_MEM_READ,
         // CMD_MEM_WRITE,
         // CMD_MEM_EXEC,

--- a/firmware/cmdnames.c
+++ b/firmware/cmdnames.c
@@ -25,7 +25,7 @@
 #include "cmdnames.h"
 #include "archcompat.h"
 
-#define STRLEN 7 /* max length of command name without zero-terminator */
+#define STRLEN 10 /* max length of command name without zero-terminator */
 #define TABLEN (sizeof(cmd_tab) / sizeof(struct cmd_struct))
 
 struct cmd_struct {
@@ -36,27 +36,30 @@ struct cmd_struct {
 // This table resides in flash memory
 
 static const struct cmd_struct IN_ROM cmd_tab[] = {
-	{"-"      , CMD_NONE       }, // command_to_name starts here
-	{"?"      , CMD_SYNTAX     },
-	{"@"      , CMD_OVERWRITE  },
-	{"$"      , CMD_DIR        },
-	{"ASSIGN" , CMD_ASSIGN     }, // command_find starts here
-	{"BLOCK"  , CMD_BLOCK      },
-	{"COPY"   , CMD_SYNTAX     }, // not yet supported but not to confuse with 'CD'
-	{"CD"     , CMD_CD         },
-	{"CHDIR"  , CMD_CD         },
-	{"INIT"   , CMD_INITIALIZE },
-	{"M-"     , CMD_SYNTAX     }, // not yet supported but not to confuse with 'MD'
-	{"MKDIR"  , CMD_MKDIR      },
-	{"MD"     , CMD_MKDIR      },
-	{"P"      , CMD_POSITION   },
-	{"RENAME" , CMD_RENAME     },
-	{"RMDIR"  , CMD_RMDIR      },
-	{"RD"     , CMD_RMDIR      },
-	{"SCRATCH", CMD_SCRATCH    },
-	{"TIME"   , CMD_TIME       },
-	{"U"      , CMD_UX         },
-	{"X"      , CMD_EXT        },
+	{"-"         , CMD_NONE       }, // command_to_name starts here
+	{"?"         , CMD_SYNTAX     },
+	{"@"         , CMD_OVERWRITE  },
+	{"$"         , CMD_DIR        },
+	{"ASSIGN"    , CMD_ASSIGN     }, // command_find starts here
+	{"BLOCK"     , CMD_BLOCK      },
+	{"COPY"      , CMD_COPY       },
+	{"CD"        , CMD_CD         },
+	{"CHDIR"     , CMD_CD         },
+   {"DUPLICATE" , CMD_DUPLICATE  },
+	{"INITIALIZE", CMD_INITIALIZE },
+	{"M-"        , CMD_SYNTAX     }, // not yet supported but not to confuse with 'MD'
+	{"MKDIR"     , CMD_MKDIR      },
+	{"MD"        , CMD_MKDIR      },
+   {"NEW"       , CMD_NEW        },
+	{"P"         , CMD_POSITION   },
+	{"RENAME"    , CMD_RENAME     },
+	{"RMDIR"     , CMD_RMDIR      },
+	{"RD"        , CMD_RMDIR      },
+	{"SCRATCH"   , CMD_SCRATCH    },
+	{"TIME"      , CMD_TIME       },
+	{"U"         , CMD_UX         },
+   {"VALIDATE"  , CMD_VALIDATE   },
+	{"X"         , CMD_EXT        },
 };
 
 /**************************************************************************

--- a/firmware/name.c
+++ b/firmware/name.c
@@ -133,7 +133,7 @@ static void parse_cmd (uint8_t *cmdstr, uint8_t len, nameinfo_t *result) {
 		result->namelen = len - cmdlen;
 		return;
 	}
-	if (result->cmd == CMD_ASSIGN || result->cmd == CMD_RENAME) {
+	if (result->cmd == CMD_ASSIGN || result->cmd == CMD_RENAME || result->cmd == CMD_COPY) {
 		// Split cmdstr at '=' for name2
 		uint8_t *equ = (uint8_t*) strchr((char*) cmdstr, '=');
 		if (equ) {


### PR DESCRIPTION
The wireformat is extended with the command:
 92 #define   FS_COPY        28   /\* copy a file or merge files _/
 93 #define   FS_DUPLICATE   29   /_ duplicate a disk image or copy a directory _/
 94 #define   FS_INITIALIZE  30   /_ initialize (e.g. free buffers and remove file locks) */
these are needed to support the new CBM commands in "cmd.h"
 49         CMD_INITIALIZE = FS_INITIALIZE,
 53         CMD_VALIDATE   = FS_CHKDSK,
 54         CMD_COPY       = FS_COPY,
 55         CMD_DUPLICATE  = FS_DUPLICATE,
 56         CMD_NEW        = FS_FORMAT,
