### PR TITLE
rename "errno_t" to "cbm_errno_t" in order to avoid name conflicts

### DIFF
--- a/common/errors.h
+++ b/common/errors.h
@@ -79,7 +79,7 @@ typedef enum {
 	CBM_ERROR_DISK_FULL		= 72,
 	CBM_ERROR_DOSVERSION		= 73,
 	CBM_ERROR_DRIVE_NOT_READY	= 74
-} errno_t;
+} cbm_errno_t;
 
 
 #endif

--- a/firmware/fatfs/dir.c
+++ b/firmware/fatfs/dir.c
@@ -70,7 +70,7 @@ char *splitpath(char *path, char **dir) {
  * returns CBM_ERROR_FILE_NAME_TOO_LONG if the buffer cannot take the resulting path
  * otherwise returns CBM_ERROR_OK
  */
-errno_t concat_path_filename(char *path, uint16_t pathmax, const char *dir, const char *name) {
+cbm_errno_t concat_path_filename(char *path, uint16_t pathmax, const char *dir, const char *name) {
 	if((strlen(dir) + 1 + strlen(name)) > pathmax) return CBM_ERROR_FILE_NAME_TOO_LONG;
 	strcpy(path, dir);
 	strcat(path, "/");
@@ -79,20 +79,20 @@ errno_t concat_path_filename(char *path, uint16_t pathmax, const char *dir, cons
 }
 
 // just a dummy action for debug purposes
-errno_t dummy_action(const char *path) {
+cbm_errno_t dummy_action(const char *path) {
 	debug_printf("--> '%s'\n", path);
 	return CBM_ERROR_OK;
 }
 
-errno_t traverse(
+cbm_errno_t traverse(
 	char		*path,			// path string (may contain wildcards and path separators)
 	uint16_t	max_matches,		// abort if this number of matches is reached
 	uint16_t	*matches,		// count number of total matches
 	uint8_t		required_flags,		// AM_DIR | AM_RDO | AM_HID | AM_SYS | AM_ARC
 	uint8_t		forbidden_flags,	// AM_DIR | AM_RDO | AM_HID | AM_SYS | AM_ARC
-	errno_t	(*action)(const char *path)	// function called by each match
+	cbm_errno_t	(*action)(const char *path)	// function called by each match
 ) {
-	errno_t cres = CBM_ERROR_OK;
+	cbm_errno_t cres = CBM_ERROR_OK;
 	FRESULT fres;
 	char *b, *d;
 	char *filename;

--- a/firmware/fatfs/dir.h
+++ b/firmware/fatfs/dir.h
@@ -40,17 +40,17 @@ char *splitpath(char *path, char **dir);
  * returns ERROR_FILE_NAME_TOO_LONG if the buffer cannot take the resulting path
  * otherwise returns ERROR_OK
  */
-errno_t concat_path_filename(char *path, uint16_t pathmax, const char *dir, const char *name);
+cbm_errno_t concat_path_filename(char *path, uint16_t pathmax, const char *dir, const char *name);
 
 
-errno_t dummy_action(const char *dir, const char *name); // just a dummy action for debug purposes
-errno_t traverse(
+cbm_errno_t dummy_action(const char *dir, const char *name); // just a dummy action for debug purposes
+cbm_errno_t traverse(
         char 		*path,                  // path string (may contain wildcards and path separators)
         uint16_t        max_matches,            // abort if this number of matches is reached
         uint16_t        *matches,               // count number of total matches
         uint8_t         required_flags,         // AM_DIR | AM_RDO | AM_HID | AM_SYS | AM_ARC
         uint8_t         forbidden_flags,        // AM_DIR | AM_RDO | AM_HID | AM_SYS | AM_ARC
-        errno_t  (*action)(const char *path)	// function called by each match
+        cbm_errno_t  (*action)(const char *path)	// function called by each match
 );
   
 

--- a/firmware/fatfs/errcompat.c
+++ b/firmware/fatfs/errcompat.c
@@ -21,7 +21,7 @@
 ***************************************************************************/
 
 
-/* ----- FatFs FRESULT errors vs CBM errno_t errors --------------------------
+/* ----- FatFs FRESULT errors vs CBM cbm_errno_t errors --------------------------
 
    Some FatFs functions depend on the error code of other internal functions,
    so making them an alias to CBM_ERROR-ones does not seem to be a good
@@ -39,7 +39,7 @@
 #error Table might be outdated
 #endif
 
-static const errno_t fresult_tbl[] IN_ROM = {
+static const cbm_errno_t fresult_tbl[] IN_ROM = {
    [FR_OK]                  = CBM_ERROR_OK,              /* (0) Succeeded */
    [FR_DISK_ERR]            = CBM_ERROR_WRITE_ERROR,     /* (1) A hard error occurred in the low level disk I/O layer */
    [FR_INT_ERR]             = CBM_ERROR_FAULT,           /* (2) Assertion failed */
@@ -62,12 +62,12 @@ static const errno_t fresult_tbl[] IN_ROM = {
    [FR_INVALID_PARAMETER]   = CBM_ERROR_SYNTAX_UNKNOWN   /* (19) Given parameter is invalid */
 };
 
-errno_t conv_fresult(FRESULT fres) {
+cbm_errno_t conv_fresult(FRESULT fres) {
 	if (fres > sizeof(fresult_tbl)) return CBM_ERROR_FAULT;
 	return rom_read_byte(&fresult_tbl[fres]);
 }
 
-errno_t combine (errno_t cres, FRESULT fres) {
+cbm_errno_t combine (cbm_errno_t cres, FRESULT fres) {
 	if (cres != CBM_ERROR_OK) return cres;
 	return conv_fresult(fres);
 }

--- a/firmware/fatfs/errcompat.h
+++ b/firmware/fatfs/errcompat.h
@@ -21,7 +21,7 @@
 ***************************************************************************/
 
 
-/* ----- FatFs FRESULT errors vs CBM errno_t errors --------------------------
+/* ----- FatFs FRESULT errors vs CBM cbm_errno_t errors --------------------------
 
    Some FatFs functions depend on the error code of other internal functions,
    so making them an alias to CBM_ERROR-ones does not seem to be a good
@@ -36,7 +36,7 @@
 #include "ff.h"
 #include "errors.h"
 
-errno_t conv_fresult(FRESULT fres);
-errno_t combine (errno_t cres, FRESULT fres);
+cbm_errno_t conv_fresult(FRESULT fres);
+cbm_errno_t combine (cbm_errno_t cres, FRESULT fres);
 
 #endif

--- a/firmware/fatfs/fat_provider.c
+++ b/firmware/fatfs/fat_provider.c
@@ -126,8 +126,8 @@ static struct {
 // ----- Prototypes --------------------------------------------------------
 
 // helper functions
-static errno_t fs_read_dir(void *epdata, int8_t channelno, packet_t *packet);
-static errno_t fs_move(char *buf);
+static cbm_errno_t fs_read_dir(void *epdata, int8_t channelno, packet_t *packet);
+static cbm_errno_t fs_move(char *buf);
 static void fs_delete(char *path, packet_t *p);
 
 // Copy a filename/path limited to 16 characters
@@ -181,7 +181,7 @@ static FIL *tbl_ins_file(uint8_t chan) {
    return NULL;
 }
 
-static errno_t tbl_ins_dir(int8_t chan) {
+static cbm_errno_t tbl_ins_dir(int8_t chan) {
    for(uint8_t i=0; i < FAT_MAX_FILES; i++) {
       if(tbl[i].chan == chan) {
          debug_printf("dir_state #%d := DIR_HEAD\n", i);
@@ -210,9 +210,9 @@ static FIL *tbl_find_file(uint8_t chan) {
    return &tbl[pos].f;
 }
 
-static errno_t tbl_close_file(uint8_t chan) {
+static cbm_errno_t tbl_close_file(uint8_t chan) {
    int8_t pos;
-   errno_t cres = CBM_ERROR_OK;
+   cbm_errno_t cres = CBM_ERROR_OK;
    FRESULT fres = FR_OK;
 
    if((pos = tbl_chpos(chan)) != AVAILABLE) {
@@ -571,7 +571,7 @@ static void fat_submit_call(void *epdata, int8_t channelno, packet_t *txbuf, pac
 
 // ----- Directories -------------------------------------------------------
 
-errno_t fs_read_dir(void *epdata, int8_t channelno, packet_t *packet) {
+cbm_errno_t fs_read_dir(void *epdata, int8_t channelno, packet_t *packet) {
    FRESULT fres;
    int8_t tblpos = tbl_chpos(channelno);
    char *p = (char *) packet->buffer;
@@ -706,7 +706,7 @@ errno_t fs_read_dir(void *epdata, int8_t channelno, packet_t *packet) {
 
 // ----- Rename a file or directory ----------------------------------------
 
-static errno_t fs_move(char *buf) {
+static cbm_errno_t fs_move(char *buf) {
    // Rename/move a file or directory
    // DO NOT RENAME/MOVE OPEN OBJECTS!
    FRESULT fres;
@@ -734,7 +734,7 @@ static errno_t fs_move(char *buf) {
 
 // ----- Delete files ------------------------------------------------------
 
-errno_t _scratch(const char *path) {
+cbm_errno_t _scratch(const char *path) {
    debug_printf("Scratching '%s'\n", path);
    FRESULT fres = f_unlink(path);
    if(fres) debug_printf("f_unlink: %d\n", fres);
@@ -748,7 +748,7 @@ errno_t _scratch(const char *path) {
    in case of any errors
 */
 static void fs_delete(char *path, packet_t *packet) {
-   errno_t cres = CBM_ERROR_OK;
+   cbm_errno_t cres = CBM_ERROR_OK;
    uint16_t files_scratched = 0;
    char *pnext;
 

--- a/firmware/rtconfig.c
+++ b/firmware/rtconfig.c
@@ -204,13 +204,13 @@ void rtconfig_pullconfig() {
 /********************************************************************************/
 
 // set from an X command
-errno_t rtconfig_set(rtconfig_t *rtc, const char *cmd) {
+cbm_errno_t rtconfig_set(rtconfig_t *rtc, const char *cmd) {
 
 	charset_t new_charset = -1;
 
 	debug_printf("CMD:'%s'\n", cmd);
 
-	errno_t er = CBM_ERROR_SYNTAX_UNKNOWN;
+	cbm_errno_t er = CBM_ERROR_SYNTAX_UNKNOWN;
 
 	const char *ptr = cmd;
 

--- a/firmware/rtconfig.h
+++ b/firmware/rtconfig.h
@@ -44,7 +44,7 @@ void rtconfig_init(endpoint_t *ep);
 void rtconfig_init_rtc(rtconfig_t *rtc, uint8_t devaddr);
 
 // set from an X command
-errno_t rtconfig_set(rtconfig_t *rtc, const char *cmd);
+cbm_errno_t rtconfig_set(rtconfig_t *rtc, const char *cmd);
 
 // send an FS_RESET packet and pull in cmdline options
 // also tries to send the preferred character set

--- a/pcserver/terminal.c
+++ b/pcserver/terminal.c
@@ -149,7 +149,7 @@ int terminal_init (void) {
 		green	= strdup(tiparm(tigetstr("setaf"), 2));
 		yellow	= strdup(tiparm(tigetstr("setaf"), 3));
                 if(boldstr) {
-		   blue	= malloc(strlen(boldstr) + strlen(tiparm(tigetstr("setaf"))) + 1);
+		   blue	= malloc(strlen(boldstr) + strlen(tiparm(tigetstr("setaf"), 4)) + 1);
                    if(!blue) {
                       log_error("malloc failed!\n");
                       exit(1);


### PR DESCRIPTION
rename "errno_t" to "cbm_errno_t" in order to avoid name conflicts while compiling on Apple OSX 10.9
also insert missing parameter into a call to tiparm.
