### PR TITLE
Initialize local variables which cause clang warning messages if not ini...

### DIFF
--- a/pcserver/fs_provider.c
+++ b/pcserver/fs_provider.c
@@ -567,7 +567,7 @@ static void close_fds(endpoint_t *ep, int tfd) {
 // open a file for reading, writing, or appending
 static int open_file(endpoint_t *ep, int tfd, const char *buf, const char *opts, int *reclen, int fs_cmd) {
 	int er = CBM_ERROR_FAULT;
-	File *file;
+	File *file=NULL;
 
 	uint16_t recordlen = 0;
 	uint8_t type;

--- a/pcserver/fscmd.c
+++ b/pcserver/fscmd.c
@@ -155,7 +155,7 @@ void cmd_assign_from_cmdline(int argc, char *argv[]) {
 			}
 	
 			// int rv = provider_assign(argv[i][2] & 0x0f, &(argv[i][4]));
-			int rv;
+			int rv=0;
 			int drive = argv[i][2] & 0x0f;
 			char provider_name[MAX_LEN_OF_PROVIDER_NAME + 1];
 			char *provider_parameter;

--- a/pcserver/fsser.c
+++ b/pcserver/fsser.c
@@ -77,10 +77,10 @@ void usage(int rv) {
 
 
 int main(int argc, char *argv[]) {
-	serial_port_t writefd, readfd;
+	serial_port_t writefd=0, readfd=0;
 	serial_port_t fdesc;
 	int i;
-	char *dir;
+	char *dir=NULL;
 	char *device = NULL;	/* device name or NULL if stdin/out */
 	char parameter_d_given = FALSE;
 

--- a/pcserver/tcp_provider.c
+++ b/pcserver/tcp_provider.c
@@ -263,7 +263,7 @@ static void close_fds(endpoint_t *ep, int tfd) {
 static int open_file(endpoint_t *ep, int tfd, const char *buf, const char *mode) {
 	int ern;
 	int er = CBM_ERROR_FAULT;
-	File *file;
+	File *file=NULL;
 	struct addrinfo *addr, *ap;
 	struct addrinfo hints;
 	int sockfd;


### PR DESCRIPTION
...tialized.

Fix #124
