### PR TITLE
Make the colon ':' optional in B-X block commands

### DIFF
--- a/firmware/bufcmd.c
+++ b/firmware/bufcmd.c
@@ -562,16 +562,15 @@ uint8_t cmd_block(bus_t *bus, char *cmdbuf, errormsg_t *error) {
 	}
 	cmdbuf++;
 
-	char cchar = *cmdbuf;
+	char cchar = *cmdbuf++;
 	
-	while (*cmdbuf != 0 && *cmdbuf != ':') {
+	// skip blanks and colon before parameters
+	while (*cmdbuf == ' ' || *cmdbuf == ':') {
 		cmdbuf++;
 	}
 	if (*cmdbuf == 0) {
 		return CBM_ERROR_SYNTAX_UNKNOWN;
 	}
-	// char after the ':'
-	cmdbuf++;	
 		
 	switch(cchar) {
 	case 'A':


### PR DESCRIPTION
Allows CBM DOS block commands with or without colon as documented in various user's guides.
