### PR TITLE
print last_push_error only for values != 0

### DIFF
--- a/firmware/bus.c
+++ b/firmware/bus.c
@@ -286,7 +286,7 @@ int16_t bus_sendbyte(bus_t *bus, uint8_t data, uint8_t with_eoi) {
     } else {
       if (bus->channel != NULL) {
 	int8_t err = channel_put(bus->channel, data, with_eoi);
-debug_printf("last_push_error: %d (ch=%p)\n", err, bus->channel);
+	if (err) debug_printf("last_push_error: %d (ch=%p)\n", err, bus->channel);
 	if (err != CBM_ERROR_OK) {
 	  int8_t errdrive = bus->rtconf.errmsg_with_drive ? bus->channel->drive : -1;
 	  set_error_tsd(&error, err, 0, 0, errdrive);

--- a/firmware/channel.c
+++ b/firmware/channel.c
@@ -473,7 +473,7 @@ static uint8_t _push_callback(int8_t channelno, int8_t errnum, packet_t *rxpacke
 			p->last_push_errorno = CBM_ERROR_OK;
 		}
 #ifdef DEBUG_CHANNEL
-		debug_printf("last_push_errno -> %d\n", p->last_push_errorno);
+		if (p->last_push_errorno) debug_printf("last_push_errno -> %d\n", p->last_push_errorno);
 #endif
 
                 // TODO: only if errorno == 0?


### PR DESCRIPTION
suppressing debug output for no error conditions enhances performance
